### PR TITLE
Add identifier registry to plugin context

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -12,6 +12,7 @@ sourceCompatibility = '17'
 targetCompatibility = '17'
 
 repositories {
+	mavenLocal()
 	mavenCentral()
 }
 
@@ -51,8 +52,10 @@ dependencies {
 	implementation 'jakarta.servlet.jsp.jstl:jakarta.servlet.jsp.jstl-api:3.0.0'
 	implementation 'org.glassfish.web:jakarta.servlet.jsp.jstl:3.0.1'
 
-	implementation 'com.structurizr:structurizr-dsl:1.33.0'
+	implementation 'com.structurizr:structurizr-dsl:1.33.1'
 	implementation 'com.structurizr:structurizr-graphviz:2.2.2'
+	implementation 'com.structurizr:structurizr-client:1.27.0'
+	implementation 'com.structurizr:structurizr-import:1.6.0'
 
 	implementation 'org.apache.httpcomponents.client5:httpclient5:5.2.1'
 


### PR DESCRIPTION
It uses a custom version of the `structurize-dsl` library and is required for manual testing of https://github.com/structurizr/dsl/pull/367

To rub the service use the general instruction here: https://github.com/structurizr/lite#building-from-source 